### PR TITLE
make geometry4Sharp target both net 7.0 and 8.0

### DIFF
--- a/geometry4Sharp_netstandard.csproj
+++ b/geometry4Sharp_netstandard.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>g4</RootNamespace>


### PR DESCRIPTION
make geometry4Sharp target both net 7.0 and 8.0

TBR cc @hjforsythe-rlp @marianamarasoiu @lukechurch